### PR TITLE
Implement keychain types and refactor builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,18 @@ which does not rely on e.g. Core Foundation types.
 
 ## Status
 
-This crate only wraps a small part of the Keychain Services API, and presently
-only supports interacting with the default keychain (i.e. `login`). Below is a
-rough outline of the Keychain Service API and what is supported.
+Below is a rough outline of the Keychain Service API and what is supported
+by this crate:
 
-- [x] Keychains (`SecKeychain`)
+- [ ] Keychains (`SecKeychain`)
   - [x] Creating keychains
   - [x] Deleting keychains
+  - [ ] Open keychain (`SecKeychainOpen`)
+  - [ ] Keychain status (`SecKeychainGetStatus`)
+  - [ ] Keychain version (`SecKeychainGetVersion`)
+  - [ ] Set default keychain (`SecKeychainSetDefault`)
 - [ ] Keychain Items (`SecKeychainItem`)
-  - [ ] Creating keychain item attributes
+  - [ ] Creating keychain items
   - [ ] Fetching keychain items
   - [ ] Getting keychain item attributes
   - [ ] Deleting keychain items

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -1,0 +1,73 @@
+//! Builder for constructing a `CFDictionary` from attribute pairs.
+
+use core_foundation::{
+    self,
+    base::{CFType, TCFType},
+    boolean::CFBoolean,
+    number::CFNumber,
+    string::{CFString, CFStringRef},
+};
+
+use attr::TSecAttr;
+
+/// All CFDictionary types we use follow this signature
+pub type CFDictionary = core_foundation::dictionary::CFDictionary<CFType, CFType>;
+
+/// Builder for attribute/parameter dictionaries we pass as arguments.
+#[derive(Clone, Default, Debug)]
+pub(crate) struct CFDictionaryBuilder(Vec<(CFType, CFType)>);
+
+impl CFDictionaryBuilder {
+    /// Create a new dictionary builder
+    pub(crate) fn new() -> CFDictionaryBuilder {
+        CFDictionaryBuilder(vec![])
+    }
+
+    /// Add a key/value pair to the dictionary
+    pub(crate) fn add<K, V>(&mut self, key: K, value: &V)
+    where
+        K: Into<CFStringRef>,
+        V: TCFType,
+    {
+        self.0.push((
+            unsafe { CFString::wrap_under_get_rule(key.into()) }.as_CFType(),
+            value.as_CFType(),
+        ))
+    }
+
+    /// Add an attribute (i.e. `TSecAttr`) to the dictionary
+    pub(crate) fn add_attr(&mut self, attr: &TSecAttr) {
+        self.add(attr.kind(), &attr.as_CFType())
+    }
+
+    /// Add a key/value pair with a `bool` value to the dictionary
+    pub(crate) fn add_boolean<K>(&mut self, key: K, value: bool)
+    where
+        K: Into<CFStringRef>,
+    {
+        self.add(key, &CFBoolean::from(value))
+    }
+
+    /// Add a key/value pair with an `i64` value to the dictionary
+    pub(crate) fn add_number<K>(&mut self, key: K, value: i64)
+    where
+        K: Into<CFStringRef>,
+    {
+        self.add(key, &CFNumber::from(value))
+    }
+
+    /// Add a key/value pair with an `AsRef<str>` value to the dictionary
+    pub(crate) fn add_string<K, V>(&mut self, key: K, value: V)
+    where
+        K: Into<CFStringRef>,
+        V: AsRef<str>,
+    {
+        self.add(key, &CFString::from(value.as_ref()))
+    }
+}
+
+impl From<CFDictionaryBuilder> for CFDictionary {
+    fn from(builder: CFDictionaryBuilder) -> CFDictionary {
+        CFDictionary::from_CFType_pairs(&builder.0)
+    }
+}

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -25,9 +25,16 @@ pub(crate) type SecKeyRef = CFTypeRef;
 /// <https://developer.apple.com/documentation/security/seckeychainref>
 pub(crate) type SecKeychainRef = CFTypeRef;
 
+/// Reference to a `SecKeychainItem`
+///
+/// See `SecKeychainItemRef` documentation:
+/// <https://developer.apple.com/documentation/security/seckeychainitemref>
+pub(crate) type SecKeychainItemRef = CFTypeRef;
+
 #[link(name = "Security", kind = "framework")]
 extern "C" {
     pub(crate) static kSecAttrAccessControl: CFStringRef;
+    pub(crate) static kSecAttrAccessible: CFStringRef;
     pub(crate) static kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly: CFStringRef;
     pub(crate) static kSecAttrAccessibleWhenUnlockedThisDeviceOnly: CFStringRef;
     pub(crate) static kSecAttrAccessibleWhenUnlocked: CFStringRef;
@@ -35,9 +42,9 @@ extern "C" {
     pub(crate) static kSecAttrAccessibleAfterFirstUnlock: CFStringRef;
     pub(crate) static kSecAttrAccessibleAlwaysThisDeviceOnly: CFStringRef;
     pub(crate) static kSecAttrAccessibleAlways: CFStringRef;
+    pub(crate) static kSecAttrAccount: CFStringRef;
     pub(crate) static kSecAttrApplicationLabel: CFStringRef;
     pub(crate) static kSecAttrApplicationTag: CFStringRef;
-    pub(crate) static kSecClass: CFStringRef;
     pub(crate) static kSecAttrIsPermanent: CFStringRef;
     pub(crate) static kSecAttrKeyClass: CFStringRef;
     pub(crate) static kSecAttrKeyClassPublic: CFStringRef;
@@ -49,9 +56,44 @@ extern "C" {
     pub(crate) static kSecAttrKeyTypeECSECPrimeRandom: CFStringRef;
     pub(crate) static kSecAttrKeySizeInBits: CFStringRef;
     pub(crate) static kSecAttrLabel: CFStringRef;
+    pub(crate) static kSecAttrProtocol: CFStringRef;
+    pub(crate) static kSecAttrProtocolFTP: CFStringRef;
+    pub(crate) static kSecAttrProtocolFTPAccount: CFStringRef;
+    pub(crate) static kSecAttrProtocolHTTP: CFStringRef;
+    pub(crate) static kSecAttrProtocolIRC: CFStringRef;
+    pub(crate) static kSecAttrProtocolNNTP: CFStringRef;
+    pub(crate) static kSecAttrProtocolPOP3: CFStringRef;
+    pub(crate) static kSecAttrProtocolSMTP: CFStringRef;
+    pub(crate) static kSecAttrProtocolSOCKS: CFStringRef;
+    pub(crate) static kSecAttrProtocolIMAP: CFStringRef;
+    pub(crate) static kSecAttrProtocolLDAP: CFStringRef;
+    pub(crate) static kSecAttrProtocolAppleTalk: CFStringRef;
+    pub(crate) static kSecAttrProtocolAFP: CFStringRef;
+    pub(crate) static kSecAttrProtocolTelnet: CFStringRef;
+    pub(crate) static kSecAttrProtocolSSH: CFStringRef;
+    pub(crate) static kSecAttrProtocolFTPS: CFStringRef;
+    pub(crate) static kSecAttrProtocolHTTPS: CFStringRef;
+    pub(crate) static kSecAttrProtocolHTTPProxy: CFStringRef;
+    pub(crate) static kSecAttrProtocolHTTPSProxy: CFStringRef;
+    pub(crate) static kSecAttrProtocolFTPProxy: CFStringRef;
+    pub(crate) static kSecAttrProtocolSMB: CFStringRef;
+    pub(crate) static kSecAttrProtocolRTSP: CFStringRef;
+    pub(crate) static kSecAttrProtocolRTSPProxy: CFStringRef;
+    pub(crate) static kSecAttrProtocolDAAP: CFStringRef;
+    pub(crate) static kSecAttrProtocolEPPC: CFStringRef;
+    pub(crate) static kSecAttrProtocolIPP: CFStringRef;
+    pub(crate) static kSecAttrProtocolNNTPS: CFStringRef;
+    pub(crate) static kSecAttrProtocolLDAPS: CFStringRef;
+    pub(crate) static kSecAttrProtocolTelnetS: CFStringRef;
+    pub(crate) static kSecAttrProtocolIMAPS: CFStringRef;
+    pub(crate) static kSecAttrProtocolIRCS: CFStringRef;
+    pub(crate) static kSecAttrProtocolPOP3S: CFStringRef;
+    pub(crate) static kSecAttrServer: CFStringRef;
+    pub(crate) static kSecAttrService: CFStringRef;
     pub(crate) static kSecAttrSynchronizable: CFStringRef;
     pub(crate) static kSecAttrTokenID: CFStringRef;
     pub(crate) static kSecAttrTokenIDSecureEnclave: CFStringRef;
+    pub(crate) static kSecClass: CFStringRef;
     pub(crate) static kSecClassGenericPassword: CFStringRef;
     pub(crate) static kSecClassInternetPassword: CFStringRef;
     pub(crate) static kSecClassCertificate: CFStringRef;
@@ -177,6 +219,7 @@ extern "C" {
         privateKey: *mut SecKeyRef,
     ) -> OSStatus;
     pub(crate) fn SecKeyGetTypeID() -> CFTypeID;
+    pub(crate) fn SecKeychainCopyDefault(keychain: *mut SecKeychainRef) -> OSStatus;
     pub(crate) fn SecKeychainCreate(
         path_name: *const c_char,
         password_length: u32,
@@ -187,4 +230,5 @@ extern "C" {
     ) -> OSStatus;
     pub(crate) fn SecKeychainDelete(keychain_or_array: SecKeychainRef) -> OSStatus;
     pub(crate) fn SecKeychainGetTypeID() -> CFTypeID;
+    pub(crate) fn SecKeychainItemGetTypeID() -> CFTypeID;
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -2,6 +2,20 @@ use core_foundation::{base::TCFType, string::CFString};
 
 use ffi::*;
 
+declare_TCFType!{
+    /// Items stored in the keychain.
+    ///
+    /// Wrapper for the `SecKeychainItem`/`SecKeychainItemRef` types:
+    /// <https://developer.apple.com/documentation/security/seckeychainitemref>
+    SecKeychainItem, SecKeychainItemRef
+}
+
+impl_TCFType!(
+    SecKeychainItem,
+    SecKeychainItemRef,
+    SecKeychainItemGetTypeID
+);
+
 /// Classes of keys supported by Keychain Services (not to be confused with
 /// `SecAttrClass` or `SecType`)
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,34 @@
 //! For more information on Keychain Services`, see:
 //! <https://developer.apple.com/documentation/security/keychain_services/keychains>
 //!
-//! TODO: merge this into the `security-framework` crate:
-//! <https://crates.io/crates/security-framework>
+//! ## Code Signing
+//!
+//! The Keychain Service API requires signed code to access much of its
+//! functionality. Accessing many APIs from an unsigned app will return
+//! an error with a kind of `ErrorKind::MissingEntitlement`.
+//!
+//! Follow the instructions here to create a self-signed code signing certificate:
+//! <https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html>
+//!
+//! You will need to use the [codesign] command-line utility (or XCode) to sign
+//! your code before it will be able to access most Keychain Services API
+//! functionality. When you sign, you will need an entitlements file which
+//! grants access to the Keychain Services API. Below is an example:
+//!
+//! ```xml
+//! <?xml version="1.0" encoding="UTF-8"?>
+//! <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+//! <plist version="1.0">
+//! <dict>
+//!	<key>keychain-access-groups</key>
+//!	<array>
+//!		<string>$(AppIdentifierPrefix)com.example.MyApplication</string>
+//!	</array>
+//! </dict>
+//! </plist>
+//! ```
+//!
+//! [codesign]: https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html#//apple_ref/doc/uid/TP40005929-CH4-SW4
 
 #![crate_name = "keychain_services"]
 #![crate_type = "rlib"]
@@ -39,6 +65,7 @@ extern crate failure_derive;
 mod access;
 mod algorithm;
 mod attr;
+mod dictionary;
 mod error;
 mod ffi;
 mod item;

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -19,7 +19,7 @@ fn generate_and_sign_with_ecdsa_keys() {
             .unwrap();
 
     let generate_params =
-        SecKeyGeneratePairParams::new(SecAttrKeyType::EcSecPrimeRandom, 256).access_control(acl);
+        SecKeyGeneratePairParams::new(SecAttrKeyType::EcSecPrimeRandom, 256).access_control(&acl);
 
     let keypair = SecKeyPair::generate(generate_params).unwrap();
 


### PR DESCRIPTION
This adds basic keychain and keychain item types.

It also adds a dictionary builder to simplify parameter construction. Specifically attributes now support a `TSecAttr` trait, and the dictionary builder can add the key and value automatically for any type
that implements this trait.