### PR TITLE
Remove 'Sec*' prefix from all type names

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -4,10 +4,10 @@ use ffi::*;
 
 /// Cryptographic algorithms for use with keys stored in the keychain.
 ///
-/// For more information on `SecKeyAlgorithm`, see:
-/// <https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values>
+/// Wrapper for `SecKeyAlgorithm`. See:
+/// <https://developer.apple.com/documentation/security/seckeyalgorithm>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecKeyAlgorithm {
+pub enum KeyAlgorithm {
     /// Elliptic Curve Encryption Standard X963
     ECIESEncryptionStandardX963SHA1AESGCM,
 
@@ -236,216 +236,214 @@ pub enum SecKeyAlgorithm {
     RSASignatureMessagePSSSHA512,
 }
 
-impl SecKeyAlgorithm {
+impl KeyAlgorithm {
     /// Get `CFString` containing the `kSecKeyAlgorithm` dictionary value for
     /// a particular cryptographic algorithm.
     pub fn as_CFString(self) -> CFString {
         unsafe {
             CFString::wrap_under_get_rule(match self {
-                SecKeyAlgorithm::ECIESEncryptionStandardX963SHA1AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardX963SHA1AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardX963SHA1AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardX963SHA224AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardX963SHA224AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardX963SHA224AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardX963SHA256AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardX963SHA256AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardX963SHA256AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardX963SHA384AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardX963SHA384AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardX963SHA384AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardX963SHA512AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardX963SHA512AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardX963SHA512AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA224AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA224AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA224AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA256AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA256AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA256AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA384AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA384AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA384AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA512AESGCM => {
+                KeyAlgorithm::ECIESEncryptionStandardVariableIVX963SHA512AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionStandardVariableIVX963SHA512AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA224AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA224AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA224AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA256AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA256AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA256AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA384AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA384AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA384AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA512AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorVariableIVX963SHA512AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorVariableIVX963SHA512AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorX963SHA1AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorX963SHA1AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorX963SHA1AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorX963SHA224AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorX963SHA224AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorX963SHA224AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorX963SHA256AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorX963SHA256AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorX963SHA256AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorX963SHA384AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorX963SHA384AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorX963SHA384AESGCM
                 }
-                SecKeyAlgorithm::ECIESEncryptionCofactorX963SHA512AESGCM => {
+                KeyAlgorithm::ECIESEncryptionCofactorX963SHA512AESGCM => {
                     kSecKeyAlgorithmECIESEncryptionCofactorX963SHA512AESGCM
                 }
-                SecKeyAlgorithm::ECDSASignatureRFC4754 => kSecKeyAlgorithmECDSASignatureRFC4754,
-                SecKeyAlgorithm::ECDSASignatureDigestX962 => {
-                    kSecKeyAlgorithmECDSASignatureDigestX962
-                }
-                SecKeyAlgorithm::ECDSASignatureDigestX962SHA1 => {
+                KeyAlgorithm::ECDSASignatureRFC4754 => kSecKeyAlgorithmECDSASignatureRFC4754,
+                KeyAlgorithm::ECDSASignatureDigestX962 => kSecKeyAlgorithmECDSASignatureDigestX962,
+                KeyAlgorithm::ECDSASignatureDigestX962SHA1 => {
                     kSecKeyAlgorithmECDSASignatureDigestX962SHA1
                 }
-                SecKeyAlgorithm::ECDSASignatureDigestX962SHA224 => {
+                KeyAlgorithm::ECDSASignatureDigestX962SHA224 => {
                     kSecKeyAlgorithmECDSASignatureDigestX962SHA224
                 }
-                SecKeyAlgorithm::ECDSASignatureDigestX962SHA256 => {
+                KeyAlgorithm::ECDSASignatureDigestX962SHA256 => {
                     kSecKeyAlgorithmECDSASignatureDigestX962SHA256
                 }
-                SecKeyAlgorithm::ECDSASignatureDigestX962SHA384 => {
+                KeyAlgorithm::ECDSASignatureDigestX962SHA384 => {
                     kSecKeyAlgorithmECDSASignatureDigestX962SHA384
                 }
-                SecKeyAlgorithm::ECDSASignatureDigestX962SHA512 => {
+                KeyAlgorithm::ECDSASignatureDigestX962SHA512 => {
                     kSecKeyAlgorithmECDSASignatureDigestX962SHA512
                 }
-                SecKeyAlgorithm::ECDSASignatureMessageX962SHA1 => {
+                KeyAlgorithm::ECDSASignatureMessageX962SHA1 => {
                     kSecKeyAlgorithmECDSASignatureMessageX962SHA1
                 }
-                SecKeyAlgorithm::ECDSASignatureMessageX962SHA224 => {
+                KeyAlgorithm::ECDSASignatureMessageX962SHA224 => {
                     kSecKeyAlgorithmECDSASignatureMessageX962SHA224
                 }
-                SecKeyAlgorithm::ECDSASignatureMessageX962SHA256 => {
+                KeyAlgorithm::ECDSASignatureMessageX962SHA256 => {
                     kSecKeyAlgorithmECDSASignatureMessageX962SHA256
                 }
-                SecKeyAlgorithm::ECDSASignatureMessageX962SHA384 => {
+                KeyAlgorithm::ECDSASignatureMessageX962SHA384 => {
                     kSecKeyAlgorithmECDSASignatureMessageX962SHA384
                 }
-                SecKeyAlgorithm::ECDSASignatureMessageX962SHA512 => {
+                KeyAlgorithm::ECDSASignatureMessageX962SHA512 => {
                     kSecKeyAlgorithmECDSASignatureMessageX962SHA512
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeCofactor => kSecKeyAlgorithmECDHKeyExchangeCofactor,
-                SecKeyAlgorithm::ECDHKeyExchangeStandard => kSecKeyAlgorithmECDHKeyExchangeStandard,
-                SecKeyAlgorithm::ECDHKeyExchangeCofactorX963SHA1 => {
+                KeyAlgorithm::ECDHKeyExchangeCofactor => kSecKeyAlgorithmECDHKeyExchangeCofactor,
+                KeyAlgorithm::ECDHKeyExchangeStandard => kSecKeyAlgorithmECDHKeyExchangeStandard,
+                KeyAlgorithm::ECDHKeyExchangeCofactorX963SHA1 => {
                     kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA1
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeStandardX963SHA1 => {
+                KeyAlgorithm::ECDHKeyExchangeStandardX963SHA1 => {
                     kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA1
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeCofactorX963SHA224 => {
+                KeyAlgorithm::ECDHKeyExchangeCofactorX963SHA224 => {
                     kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA224
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeCofactorX963SHA256 => {
+                KeyAlgorithm::ECDHKeyExchangeCofactorX963SHA256 => {
                     kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA256
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeCofactorX963SHA384 => {
+                KeyAlgorithm::ECDHKeyExchangeCofactorX963SHA384 => {
                     kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA384
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeCofactorX963SHA512 => {
+                KeyAlgorithm::ECDHKeyExchangeCofactorX963SHA512 => {
                     kSecKeyAlgorithmECDHKeyExchangeCofactorX963SHA512
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeStandardX963SHA224 => {
+                KeyAlgorithm::ECDHKeyExchangeStandardX963SHA224 => {
                     kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA224
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeStandardX963SHA256 => {
+                KeyAlgorithm::ECDHKeyExchangeStandardX963SHA256 => {
                     kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA256
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeStandardX963SHA384 => {
+                KeyAlgorithm::ECDHKeyExchangeStandardX963SHA384 => {
                     kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA384
                 }
-                SecKeyAlgorithm::ECDHKeyExchangeStandardX963SHA512 => {
+                KeyAlgorithm::ECDHKeyExchangeStandardX963SHA512 => {
                     kSecKeyAlgorithmECDHKeyExchangeStandardX963SHA512
                 }
-                SecKeyAlgorithm::RSAEncryptionRaw => kSecKeyAlgorithmRSAEncryptionRaw,
-                SecKeyAlgorithm::RSAEncryptionPKCS1 => kSecKeyAlgorithmRSAEncryptionPKCS1,
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA1 => kSecKeyAlgorithmRSAEncryptionOAEPSHA1,
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA224 => kSecKeyAlgorithmRSAEncryptionOAEPSHA224,
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA256 => kSecKeyAlgorithmRSAEncryptionOAEPSHA256,
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA384 => kSecKeyAlgorithmRSAEncryptionOAEPSHA384,
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA512 => kSecKeyAlgorithmRSAEncryptionOAEPSHA512,
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA1AESGCM => {
+                KeyAlgorithm::RSAEncryptionRaw => kSecKeyAlgorithmRSAEncryptionRaw,
+                KeyAlgorithm::RSAEncryptionPKCS1 => kSecKeyAlgorithmRSAEncryptionPKCS1,
+                KeyAlgorithm::RSAEncryptionOAEPSHA1 => kSecKeyAlgorithmRSAEncryptionOAEPSHA1,
+                KeyAlgorithm::RSAEncryptionOAEPSHA224 => kSecKeyAlgorithmRSAEncryptionOAEPSHA224,
+                KeyAlgorithm::RSAEncryptionOAEPSHA256 => kSecKeyAlgorithmRSAEncryptionOAEPSHA256,
+                KeyAlgorithm::RSAEncryptionOAEPSHA384 => kSecKeyAlgorithmRSAEncryptionOAEPSHA384,
+                KeyAlgorithm::RSAEncryptionOAEPSHA512 => kSecKeyAlgorithmRSAEncryptionOAEPSHA512,
+                KeyAlgorithm::RSAEncryptionOAEPSHA1AESGCM => {
                     kSecKeyAlgorithmRSAEncryptionOAEPSHA1AESGCM
                 }
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA224AESGCM => {
+                KeyAlgorithm::RSAEncryptionOAEPSHA224AESGCM => {
                     kSecKeyAlgorithmRSAEncryptionOAEPSHA224AESGCM
                 }
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA256AESGCM => {
+                KeyAlgorithm::RSAEncryptionOAEPSHA256AESGCM => {
                     kSecKeyAlgorithmRSAEncryptionOAEPSHA256AESGCM
                 }
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA384AESGCM => {
+                KeyAlgorithm::RSAEncryptionOAEPSHA384AESGCM => {
                     kSecKeyAlgorithmRSAEncryptionOAEPSHA384AESGCM
                 }
-                SecKeyAlgorithm::RSAEncryptionOAEPSHA512AESGCM => {
+                KeyAlgorithm::RSAEncryptionOAEPSHA512AESGCM => {
                     kSecKeyAlgorithmRSAEncryptionOAEPSHA512AESGCM
                 }
-                SecKeyAlgorithm::RSASignatureRaw => kSecKeyAlgorithmRSASignatureRaw,
-                SecKeyAlgorithm::RSASignatureDigestPKCS1v15Raw => {
+                KeyAlgorithm::RSASignatureRaw => kSecKeyAlgorithmRSASignatureRaw,
+                KeyAlgorithm::RSASignatureDigestPKCS1v15Raw => {
                     kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw
                 }
-                SecKeyAlgorithm::RSASignatureDigestPKCS1v15SHA1 => {
+                KeyAlgorithm::RSASignatureDigestPKCS1v15SHA1 => {
                     kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1
                 }
-                SecKeyAlgorithm::RSASignatureDigestPKCS1v15SHA224 => {
+                KeyAlgorithm::RSASignatureDigestPKCS1v15SHA224 => {
                     kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224
                 }
-                SecKeyAlgorithm::RSASignatureDigestPKCS1v15SHA256 => {
+                KeyAlgorithm::RSASignatureDigestPKCS1v15SHA256 => {
                     kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256
                 }
-                SecKeyAlgorithm::RSASignatureDigestPKCS1v15SHA384 => {
+                KeyAlgorithm::RSASignatureDigestPKCS1v15SHA384 => {
                     kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384
                 }
-                SecKeyAlgorithm::RSASignatureDigestPKCS1v15SHA512 => {
+                KeyAlgorithm::RSASignatureDigestPKCS1v15SHA512 => {
                     kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512
                 }
-                SecKeyAlgorithm::RSASignatureMessagePKCS1v15SHA1 => {
+                KeyAlgorithm::RSASignatureMessagePKCS1v15SHA1 => {
                     kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA1
                 }
-                SecKeyAlgorithm::RSASignatureMessagePKCS1v15SHA224 => {
+                KeyAlgorithm::RSASignatureMessagePKCS1v15SHA224 => {
                     kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA224
                 }
-                SecKeyAlgorithm::RSASignatureMessagePKCS1v15SHA256 => {
+                KeyAlgorithm::RSASignatureMessagePKCS1v15SHA256 => {
                     kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256
                 }
-                SecKeyAlgorithm::RSASignatureMessagePKCS1v15SHA384 => {
+                KeyAlgorithm::RSASignatureMessagePKCS1v15SHA384 => {
                     kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA384
                 }
-                SecKeyAlgorithm::RSASignatureMessagePKCS1v15SHA512 => {
+                KeyAlgorithm::RSASignatureMessagePKCS1v15SHA512 => {
                     kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA512
                 }
-                SecKeyAlgorithm::RSASignatureDigestPSSSHA1 => {
+                KeyAlgorithm::RSASignatureDigestPSSSHA1 => {
                     kSecKeyAlgorithmRSASignatureDigestPSSSHA1
                 }
-                SecKeyAlgorithm::RSASignatureDigestPSSSHA224 => {
+                KeyAlgorithm::RSASignatureDigestPSSSHA224 => {
                     kSecKeyAlgorithmRSASignatureDigestPSSSHA224
                 }
-                SecKeyAlgorithm::RSASignatureDigestPSSSHA256 => {
+                KeyAlgorithm::RSASignatureDigestPSSSHA256 => {
                     kSecKeyAlgorithmRSASignatureDigestPSSSHA256
                 }
-                SecKeyAlgorithm::RSASignatureDigestPSSSHA384 => {
+                KeyAlgorithm::RSASignatureDigestPSSSHA384 => {
                     kSecKeyAlgorithmRSASignatureDigestPSSSHA384
                 }
-                SecKeyAlgorithm::RSASignatureDigestPSSSHA512 => {
+                KeyAlgorithm::RSASignatureDigestPSSSHA512 => {
                     kSecKeyAlgorithmRSASignatureDigestPSSSHA512
                 }
-                SecKeyAlgorithm::RSASignatureMessagePSSSHA1 => {
+                KeyAlgorithm::RSASignatureMessagePSSSHA1 => {
                     kSecKeyAlgorithmRSASignatureMessagePSSSHA1
                 }
-                SecKeyAlgorithm::RSASignatureMessagePSSSHA224 => {
+                KeyAlgorithm::RSASignatureMessagePSSSHA224 => {
                     kSecKeyAlgorithmRSASignatureMessagePSSSHA224
                 }
-                SecKeyAlgorithm::RSASignatureMessagePSSSHA256 => {
+                KeyAlgorithm::RSASignatureMessagePSSSHA256 => {
                     kSecKeyAlgorithmRSASignatureMessagePSSSHA256
                 }
-                SecKeyAlgorithm::RSASignatureMessagePSSSHA384 => {
+                KeyAlgorithm::RSASignatureMessagePSSSHA384 => {
                     kSecKeyAlgorithmRSASignatureMessagePSSSHA384
                 }
-                SecKeyAlgorithm::RSASignatureMessagePSSSHA512 => {
+                KeyAlgorithm::RSASignatureMessagePSSSHA512 => {
                     kSecKeyAlgorithmRSASignatureMessagePSSSHA512
                 }
             })

--- a/src/attr.rs
+++ b/src/attr.rs
@@ -13,11 +13,11 @@ use std::{
 
 use ffi::*;
 
-/// Trait implemented by all `SecAttr*` types to simplify adding them to
+/// Trait implemented by all `Attr*` types to simplify adding them to
 /// attribute dictionaries.
-pub(crate) trait TSecAttr {
+pub(crate) trait TAttr {
     /// Get the attribute kind (i.e. `SecAttr` enum variant) for this attribute
-    fn kind(&self) -> SecAttr;
+    fn kind(&self) -> Attr;
 
     /// Get a `CFType` object representing this attribute.
     fn as_CFType(&self) -> CFType;
@@ -26,7 +26,7 @@ pub(crate) trait TSecAttr {
 /// Enum of attribute types passed in parameter dictionaries. This wraps up
 /// access to framework constants which would otherwise be unsafe.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) enum SecAttr {
+pub(crate) enum Attr {
     /// Wrapper for the `kSecAttrAccessControl` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattraccesscontrol>
     AccessControl,
@@ -88,31 +88,31 @@ pub(crate) enum SecAttr {
     TokenId,
 }
 
-impl From<SecAttr> for CFStringRef {
-    fn from(attr: SecAttr) -> CFStringRef {
+impl From<Attr> for CFStringRef {
+    fn from(attr: Attr) -> CFStringRef {
         unsafe {
             match attr {
-                SecAttr::AccessControl => kSecAttrAccessControl,
-                SecAttr::Accessible => kSecAttrAccessible,
-                SecAttr::Account => kSecAttrAccount,
-                SecAttr::ApplicationLabel => kSecAttrApplicationLabel,
-                SecAttr::ApplicationTag => kSecAttrApplicationTag,
-                SecAttr::KeyClass => kSecAttrKeyClass,
-                SecAttr::KeySizeInBits => kSecAttrKeySizeInBits,
-                SecAttr::KeyType => kSecAttrKeyType,
-                SecAttr::IsPermanent => kSecAttrIsPermanent,
-                SecAttr::Label => kSecAttrLabel,
-                SecAttr::Protocol => kSecAttrProtocol,
-                SecAttr::Server => kSecAttrServer,
-                SecAttr::Service => kSecAttrService,
-                SecAttr::Synchronizable => kSecAttrSynchronizable,
-                SecAttr::TokenId => kSecAttrTokenID,
+                Attr::AccessControl => kSecAttrAccessControl,
+                Attr::Accessible => kSecAttrAccessible,
+                Attr::Account => kSecAttrAccount,
+                Attr::ApplicationLabel => kSecAttrApplicationLabel,
+                Attr::ApplicationTag => kSecAttrApplicationTag,
+                Attr::KeyClass => kSecAttrKeyClass,
+                Attr::KeySizeInBits => kSecAttrKeySizeInBits,
+                Attr::KeyType => kSecAttrKeyType,
+                Attr::IsPermanent => kSecAttrIsPermanent,
+                Attr::Label => kSecAttrLabel,
+                Attr::Protocol => kSecAttrProtocol,
+                Attr::Server => kSecAttrServer,
+                Attr::Service => kSecAttrService,
+                Attr::Synchronizable => kSecAttrSynchronizable,
+                Attr::TokenId => kSecAttrTokenID,
             }
         }
     }
 }
 
-unsafe impl ToVoid<CFType> for SecAttr {
+unsafe impl ToVoid<CFType> for Attr {
     fn to_void(&self) -> *const c_void {
         CFStringRef::from(*self).to_void()
     }
@@ -127,7 +127,7 @@ unsafe impl ToVoid<CFType> for SecAttr {
 /// "Accessibility Values" section of "Item Attribute Keys and Values":
 /// <https://developer.apple.com/documentation/security/keychain_services/keychain_items/item_attribute_keys_and_values>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecAttrAccessible {
+pub enum AttrAccessible {
     /// Device is unlocked and a passcode has been set on the device.
     /// <https://developer.apple.com/documentation/security/ksecattraccessiblewhenpasscodesetthisdeviceonly>
     WhenPasscodeSetThisDeviceOnly,
@@ -158,33 +158,33 @@ pub enum SecAttrAccessible {
     Always,
 }
 
-impl SecAttrAccessible {
+impl AttrAccessible {
     /// Get pointer to an accessibility value to associate with the
     /// `kSecAttrAccessible` key for a keychain item
     pub fn as_CFString(self) -> CFString {
         unsafe {
             CFString::wrap_under_get_rule(match self {
-                SecAttrAccessible::WhenPasscodeSetThisDeviceOnly => {
+                AttrAccessible::WhenPasscodeSetThisDeviceOnly => {
                     kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
                 }
-                SecAttrAccessible::WhenUnlockedThisDeviceOnly => {
+                AttrAccessible::WhenUnlockedThisDeviceOnly => {
                     kSecAttrAccessibleWhenUnlockedThisDeviceOnly
                 }
-                SecAttrAccessible::WhenUnlocked => kSecAttrAccessibleWhenUnlocked,
-                SecAttrAccessible::AfterFirstUnlockThisDeviceOnly => {
+                AttrAccessible::WhenUnlocked => kSecAttrAccessibleWhenUnlocked,
+                AttrAccessible::AfterFirstUnlockThisDeviceOnly => {
                     kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
                 }
-                SecAttrAccessible::AfterFirstUnlock => kSecAttrAccessibleAfterFirstUnlock,
-                SecAttrAccessible::AlwaysThisDeviceOnly => kSecAttrAccessibleAlwaysThisDeviceOnly,
-                SecAttrAccessible::Always => kSecAttrAccessibleAlways,
+                AttrAccessible::AfterFirstUnlock => kSecAttrAccessibleAfterFirstUnlock,
+                AttrAccessible::AlwaysThisDeviceOnly => kSecAttrAccessibleAlwaysThisDeviceOnly,
+                AttrAccessible::Always => kSecAttrAccessibleAlways,
             })
         }
     }
 }
 
-impl TSecAttr for SecAttrAccessible {
-    fn kind(&self) -> SecAttr {
-        SecAttr::Accessible
+impl TAttr for AttrAccessible {
+    fn kind(&self) -> Attr {
+        Attr::Accessible
     }
 
     fn as_CFType(&self) -> CFType {
@@ -202,12 +202,12 @@ impl TSecAttr for SecAttrAccessible {
 /// Wrapper for the `kSecAttrApplicationLabel` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecattrapplicationlabel>
 #[derive(Clone, Eq, PartialEq)]
-pub struct SecAttrApplicationLabel(pub(crate) CFData);
+pub struct AttrApplicationLabel(pub(crate) CFData);
 
-impl SecAttrApplicationLabel {
+impl AttrApplicationLabel {
     /// Create a new application label from a byte slice
     pub fn new(bytes: &[u8]) -> Self {
-        SecAttrApplicationLabel(CFData::from_buffer(bytes))
+        AttrApplicationLabel(CFData::from_buffer(bytes))
     }
 
     /// Borrow this value as a byte slice
@@ -216,28 +216,28 @@ impl SecAttrApplicationLabel {
     }
 }
 
-impl AsRef<[u8]> for SecAttrApplicationLabel {
+impl AsRef<[u8]> for AttrApplicationLabel {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl Debug for SecAttrApplicationLabel {
+impl Debug for AttrApplicationLabel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let bytes = Vec::from(self.as_bytes());
         write!(f, "SecAttrApplicationLabel({:?})", bytes)
     }
 }
 
-impl<'a> From<&'a [u8]> for SecAttrApplicationLabel {
+impl<'a> From<&'a [u8]> for AttrApplicationLabel {
     fn from(bytes: &[u8]) -> Self {
         Self::new(bytes)
     }
 }
 
-impl TSecAttr for SecAttrApplicationLabel {
-    fn kind(&self) -> SecAttr {
-        SecAttr::ApplicationLabel
+impl TAttr for AttrApplicationLabel {
+    fn kind(&self) -> Attr {
+        Attr::ApplicationLabel
     }
 
     fn as_CFType(&self) -> CFType {
@@ -255,12 +255,12 @@ impl TSecAttr for SecAttrApplicationLabel {
 /// Wrapper for the `kSecAttrApplicationTag` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecattrapplicationtag>
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SecAttrApplicationTag(pub(crate) CFData);
+pub struct AttrApplicationTag(pub(crate) CFData);
 
-impl SecAttrApplicationTag {
+impl AttrApplicationTag {
     /// Create a new application tag from a byte slice
     pub fn new(bytes: &[u8]) -> Self {
-        SecAttrApplicationTag(CFData::from_buffer(bytes))
+        AttrApplicationTag(CFData::from_buffer(bytes))
     }
 
     /// Borrow the tag data as a byte slice
@@ -274,33 +274,33 @@ impl SecAttrApplicationTag {
     }
 }
 
-impl AsRef<[u8]> for SecAttrApplicationTag {
+impl AsRef<[u8]> for AttrApplicationTag {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl Display for SecAttrApplicationTag {
+impl Display for AttrApplicationTag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", String::from_utf8_lossy(&self.0))
     }
 }
 
-impl<'a> From<&'a [u8]> for SecAttrApplicationTag {
+impl<'a> From<&'a [u8]> for AttrApplicationTag {
     fn from(bytes: &[u8]) -> Self {
         Self::new(bytes)
     }
 }
 
-impl<'a> From<&'a str> for SecAttrApplicationTag {
+impl<'a> From<&'a str> for AttrApplicationTag {
     fn from(string: &str) -> Self {
         Self::new(string.as_bytes())
     }
 }
 
-impl TSecAttr for SecAttrApplicationTag {
-    fn kind(&self) -> SecAttr {
-        SecAttr::ApplicationTag
+impl TAttr for AttrApplicationTag {
+    fn kind(&self) -> Attr {
+        Attr::ApplicationTag
     }
 
     fn as_CFType(&self) -> CFType {
@@ -313,30 +313,30 @@ impl TSecAttr for SecAttrApplicationTag {
 /// Wrapper for the `kSecAttrLabel` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecattrlabel>
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SecAttrLabel(pub(crate) CFString);
+pub struct AttrLabel(pub(crate) CFString);
 
-impl SecAttrLabel {
+impl AttrLabel {
     /// Create a new label from a `&str`
     pub fn new(label: &str) -> Self {
-        SecAttrLabel(CFString::new(label))
+        AttrLabel(CFString::new(label))
     }
 }
 
-impl Display for SecAttrLabel {
+impl Display for AttrLabel {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", &self.0)
     }
 }
 
-impl<'a> From<&'a str> for SecAttrLabel {
+impl<'a> From<&'a str> for AttrLabel {
     fn from(label: &str) -> Self {
         Self::new(label)
     }
 }
 
-impl TSecAttr for SecAttrLabel {
-    fn kind(&self) -> SecAttr {
-        SecAttr::Label
+impl TAttr for AttrLabel {
+    fn kind(&self) -> Attr {
+        Attr::Label
     }
 
     fn as_CFType(&self) -> CFType {
@@ -350,7 +350,7 @@ impl TSecAttr for SecAttrLabel {
 /// Wrapper for the `kSecAttrKeyClass` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecattrkeyclass>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecAttrKeyClass {
+pub enum AttrKeyClass {
     /// Public keys.
     ///
     /// Wrapper for the `kSecAttrKeyClassPublic` attribute value. See:
@@ -371,23 +371,23 @@ pub enum SecAttrKeyClass {
     Symmetric,
 }
 
-impl SecAttrKeyClass {
+impl AttrKeyClass {
     /// Get `CFString` containing the `kSecAttrKeyClass` dictionary value for
     /// this particular `SecAttrKeyClass`.
     pub fn as_CFString(self) -> CFString {
         unsafe {
             CFString::wrap_under_get_rule(match self {
-                SecAttrKeyClass::Public => kSecAttrKeyClassPublic,
-                SecAttrKeyClass::Private => kSecAttrKeyClassPrivate,
-                SecAttrKeyClass::Symmetric => kSecAttrKeyClassSymmetric,
+                AttrKeyClass::Public => kSecAttrKeyClassPublic,
+                AttrKeyClass::Private => kSecAttrKeyClassPrivate,
+                AttrKeyClass::Symmetric => kSecAttrKeyClassSymmetric,
             })
         }
     }
 }
 
-impl TSecAttr for SecAttrKeyClass {
-    fn kind(&self) -> SecAttr {
-        SecAttr::KeyClass
+impl TAttr for AttrKeyClass {
+    fn kind(&self) -> Attr {
+        Attr::KeyClass
     }
 
     fn as_CFType(&self) -> CFType {
@@ -396,12 +396,12 @@ impl TSecAttr for SecAttrKeyClass {
 }
 
 /// Types of keys supported by Keychain Services (not to be confused with
-/// `SecAttrKeyClass`)
+/// `AttrKeyClass`)
 ///
 /// Wrapper for the `kSecAttrKeyType` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecattrkeytype>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecAttrKeyType {
+pub enum AttrKeyType {
     /// AES algorithm.
     ///
     /// Wrapper for the `kSecAttrKeyTypeAES` attribute value. See:
@@ -422,23 +422,23 @@ pub enum SecAttrKeyType {
     EcSecPrimeRandom,
 }
 
-impl SecAttrKeyType {
+impl AttrKeyType {
     /// Get `CFString` containing the `kSecAttrKeyType` dictionary value for
     /// this particular `SecAttrKeyType`.
     pub fn as_CFString(self) -> CFString {
         unsafe {
             CFString::wrap_under_get_rule(match self {
-                SecAttrKeyType::Aes => kSecAttrKeyTypeAES,
-                SecAttrKeyType::Rsa => kSecAttrKeyTypeRSA,
-                SecAttrKeyType::EcSecPrimeRandom => kSecAttrKeyTypeECSECPrimeRandom,
+                AttrKeyType::Aes => kSecAttrKeyTypeAES,
+                AttrKeyType::Rsa => kSecAttrKeyTypeRSA,
+                AttrKeyType::EcSecPrimeRandom => kSecAttrKeyTypeECSECPrimeRandom,
             })
         }
     }
 }
 
-impl TSecAttr for SecAttrKeyType {
-    fn kind(&self) -> SecAttr {
-        SecAttr::KeyType
+impl TAttr for AttrKeyType {
+    fn kind(&self) -> Attr {
+        Attr::KeyType
     }
 
     fn as_CFType(&self) -> CFType {
@@ -452,7 +452,7 @@ impl TSecAttr for SecAttrKeyType {
 /// Wrapper for the `kSecAttrProtocol` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecattrprotocol>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecAttrProtocol {
+pub enum AttrProtocol {
     /// File Transfer Protocol
     FTP,
 
@@ -547,51 +547,51 @@ pub enum SecAttrProtocol {
     POP3S,
 }
 
-impl SecAttrProtocol {
+impl AttrProtocol {
     /// Get `CFString` containing the `kSecAttrProtocol` dictionary value for
     /// this particular `SecAttrProtocol`.
     pub fn as_CFString(self) -> CFString {
         unsafe {
             CFString::wrap_under_get_rule(match self {
-                SecAttrProtocol::FTP => kSecAttrProtocolFTP,
-                SecAttrProtocol::FTPAccount => kSecAttrProtocolFTPAccount,
-                SecAttrProtocol::HTTP => kSecAttrProtocolHTTP,
-                SecAttrProtocol::IRC => kSecAttrProtocolIRC,
-                SecAttrProtocol::NNTP => kSecAttrProtocolNNTP,
-                SecAttrProtocol::POP3 => kSecAttrProtocolPOP3,
-                SecAttrProtocol::SMTP => kSecAttrProtocolSMTP,
-                SecAttrProtocol::SOCKS => kSecAttrProtocolSOCKS,
-                SecAttrProtocol::IMAP => kSecAttrProtocolIMAP,
-                SecAttrProtocol::LDAP => kSecAttrProtocolLDAP,
-                SecAttrProtocol::AppleTalk => kSecAttrProtocolAppleTalk,
-                SecAttrProtocol::AFP => kSecAttrProtocolAFP,
-                SecAttrProtocol::Telnet => kSecAttrProtocolTelnet,
-                SecAttrProtocol::SSH => kSecAttrProtocolSSH,
-                SecAttrProtocol::FTPS => kSecAttrProtocolFTPS,
-                SecAttrProtocol::HTTPS => kSecAttrProtocolHTTPS,
-                SecAttrProtocol::HTTPProxy => kSecAttrProtocolHTTPProxy,
-                SecAttrProtocol::HTTPSProxy => kSecAttrProtocolHTTPSProxy,
-                SecAttrProtocol::FTPProxy => kSecAttrProtocolFTPProxy,
-                SecAttrProtocol::SMB => kSecAttrProtocolSMB,
-                SecAttrProtocol::RTSP => kSecAttrProtocolRTSP,
-                SecAttrProtocol::RTSPProxy => kSecAttrProtocolRTSPProxy,
-                SecAttrProtocol::DAAP => kSecAttrProtocolDAAP,
-                SecAttrProtocol::EPPC => kSecAttrProtocolEPPC,
-                SecAttrProtocol::IPP => kSecAttrProtocolIPP,
-                SecAttrProtocol::NNTPS => kSecAttrProtocolNNTPS,
-                SecAttrProtocol::LDAPS => kSecAttrProtocolLDAPS,
-                SecAttrProtocol::TelnetS => kSecAttrProtocolTelnetS,
-                SecAttrProtocol::IMAPS => kSecAttrProtocolIMAPS,
-                SecAttrProtocol::IRCS => kSecAttrProtocolIRCS,
-                SecAttrProtocol::POP3S => kSecAttrProtocolPOP3S,
+                AttrProtocol::FTP => kSecAttrProtocolFTP,
+                AttrProtocol::FTPAccount => kSecAttrProtocolFTPAccount,
+                AttrProtocol::HTTP => kSecAttrProtocolHTTP,
+                AttrProtocol::IRC => kSecAttrProtocolIRC,
+                AttrProtocol::NNTP => kSecAttrProtocolNNTP,
+                AttrProtocol::POP3 => kSecAttrProtocolPOP3,
+                AttrProtocol::SMTP => kSecAttrProtocolSMTP,
+                AttrProtocol::SOCKS => kSecAttrProtocolSOCKS,
+                AttrProtocol::IMAP => kSecAttrProtocolIMAP,
+                AttrProtocol::LDAP => kSecAttrProtocolLDAP,
+                AttrProtocol::AppleTalk => kSecAttrProtocolAppleTalk,
+                AttrProtocol::AFP => kSecAttrProtocolAFP,
+                AttrProtocol::Telnet => kSecAttrProtocolTelnet,
+                AttrProtocol::SSH => kSecAttrProtocolSSH,
+                AttrProtocol::FTPS => kSecAttrProtocolFTPS,
+                AttrProtocol::HTTPS => kSecAttrProtocolHTTPS,
+                AttrProtocol::HTTPProxy => kSecAttrProtocolHTTPProxy,
+                AttrProtocol::HTTPSProxy => kSecAttrProtocolHTTPSProxy,
+                AttrProtocol::FTPProxy => kSecAttrProtocolFTPProxy,
+                AttrProtocol::SMB => kSecAttrProtocolSMB,
+                AttrProtocol::RTSP => kSecAttrProtocolRTSP,
+                AttrProtocol::RTSPProxy => kSecAttrProtocolRTSPProxy,
+                AttrProtocol::DAAP => kSecAttrProtocolDAAP,
+                AttrProtocol::EPPC => kSecAttrProtocolEPPC,
+                AttrProtocol::IPP => kSecAttrProtocolIPP,
+                AttrProtocol::NNTPS => kSecAttrProtocolNNTPS,
+                AttrProtocol::LDAPS => kSecAttrProtocolLDAPS,
+                AttrProtocol::TelnetS => kSecAttrProtocolTelnetS,
+                AttrProtocol::IMAPS => kSecAttrProtocolIMAPS,
+                AttrProtocol::IRCS => kSecAttrProtocolIRCS,
+                AttrProtocol::POP3S => kSecAttrProtocolPOP3S,
             })
         }
     }
 }
 
-impl TSecAttr for SecAttrProtocol {
-    fn kind(&self) -> SecAttr {
-        SecAttr::Protocol
+impl TAttr for AttrProtocol {
+    fn kind(&self) -> Attr {
+        Attr::Protocol
     }
 
     fn as_CFType(&self) -> CFType {
@@ -605,7 +605,7 @@ impl TSecAttr for SecAttrProtocol {
 /// Wrapper for the `kSecAttrTokenID` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecattrtokenid>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecAttrTokenId {
+pub enum AttrTokenId {
     /// Secure Enclave Processor (SEP), e.g. T1/T2 chip.
     ///
     /// Wrapper for the `kSecAttrTokenIDSecureEnclave` attribute value. See:
@@ -613,21 +613,21 @@ pub enum SecAttrTokenId {
     SecureEnclave,
 }
 
-impl SecAttrTokenId {
+impl AttrTokenId {
     /// Get `CFString` containing the `kSecAttrTokenID` dictionary value for
     /// this particular `SecAttrTokenId`.
     pub fn as_CFString(self) -> CFString {
         unsafe {
             CFString::wrap_under_get_rule(match self {
-                SecAttrTokenId::SecureEnclave => kSecAttrTokenIDSecureEnclave,
+                AttrTokenId::SecureEnclave => kSecAttrTokenIDSecureEnclave,
             })
         }
     }
 }
 
-impl TSecAttr for SecAttrTokenId {
-    fn kind(&self) -> SecAttr {
-        SecAttr::TokenId
+impl TAttr for AttrTokenId {
+    fn kind(&self) -> Attr {
+        Attr::TokenId
     }
 
     fn as_CFType(&self) -> CFType {

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -8,19 +8,19 @@ use core_foundation::{
     string::{CFString, CFStringRef},
 };
 
-use attr::TSecAttr;
+use attr::TAttr;
 
 /// All CFDictionary types we use follow this signature
-pub type CFDictionary = core_foundation::dictionary::CFDictionary<CFType, CFType>;
+pub(crate) type Dictionary = core_foundation::dictionary::CFDictionary<CFType, CFType>;
 
 /// Builder for attribute/parameter dictionaries we pass as arguments.
 #[derive(Clone, Default, Debug)]
-pub(crate) struct CFDictionaryBuilder(Vec<(CFType, CFType)>);
+pub(crate) struct DictionaryBuilder(Vec<(CFType, CFType)>);
 
-impl CFDictionaryBuilder {
+impl DictionaryBuilder {
     /// Create a new dictionary builder
-    pub(crate) fn new() -> CFDictionaryBuilder {
-        CFDictionaryBuilder(vec![])
+    pub(crate) fn new() -> DictionaryBuilder {
+        DictionaryBuilder(vec![])
     }
 
     /// Add a key/value pair to the dictionary
@@ -36,7 +36,7 @@ impl CFDictionaryBuilder {
     }
 
     /// Add an attribute (i.e. `TSecAttr`) to the dictionary
-    pub(crate) fn add_attr(&mut self, attr: &TSecAttr) {
+    pub(crate) fn add_attr(&mut self, attr: &TAttr) {
         self.add(attr.kind(), &attr.as_CFType())
     }
 
@@ -66,8 +66,8 @@ impl CFDictionaryBuilder {
     }
 }
 
-impl From<CFDictionaryBuilder> for CFDictionary {
-    fn from(builder: CFDictionaryBuilder) -> CFDictionary {
-        CFDictionary::from_CFType_pairs(&builder.0)
+impl From<DictionaryBuilder> for Dictionary {
+    fn from(builder: DictionaryBuilder) -> Dictionary {
+        Dictionary::from_CFType_pairs(&builder.0)
     }
 }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -11,25 +11,25 @@ use std::os::raw::{c_char, c_void};
 ///
 /// See `SecAccessControlRef` documentation:
 /// <https://developer.apple.com/documentation/security/secaccesscontrolref>
-pub(crate) type SecAccessControlRef = CFTypeRef;
+pub(crate) type AccessControlRef = CFTypeRef;
 
-/// Reference to a `SecKey`
+/// Reference to a `Key`
 ///
 /// See `SecKeyRef` documentation:
 /// <https://developer.apple.com/documentation/security/seckeyref>
-pub(crate) type SecKeyRef = CFTypeRef;
+pub(crate) type KeyRef = CFTypeRef;
 
-/// Reference to a `SecKeychain`
+/// Reference to a `Keychain`
 ///
 /// See `SecKeychainRef` documentation:
 /// <https://developer.apple.com/documentation/security/seckeychainref>
-pub(crate) type SecKeychainRef = CFTypeRef;
+pub(crate) type KeychainRef = CFTypeRef;
 
-/// Reference to a `SecKeychainItem`
+/// Reference to a `KeychainItem`
 ///
 /// See `SecKeychainItemRef` documentation:
 /// <https://developer.apple.com/documentation/security/seckeychainitemref>
-pub(crate) type SecKeychainItemRef = CFTypeRef;
+pub(crate) type KeychainItemRef = CFTypeRef;
 
 #[link(name = "Security", kind = "framework")]
 extern "C" {
@@ -202,33 +202,33 @@ extern "C" {
         reserved: *const c_void,
     ) -> CFStringRef;
     pub(crate) fn SecItemCopyMatching(query: CFDictionaryRef, result: *mut CFTypeRef) -> OSStatus;
-    pub(crate) fn SecKeyCopyAttributes(key: SecKeyRef) -> CFDictionaryRef;
+    pub(crate) fn SecKeyCopyAttributes(key: KeyRef) -> CFDictionaryRef;
     pub(crate) fn SecKeyCopyExternalRepresentation(
-        key: SecKeyRef,
+        key: KeyRef,
         error: *mut CFErrorRef,
     ) -> CFDataRef;
     pub(crate) fn SecKeyCreateSignature(
-        key: SecKeyRef,
+        key: KeyRef,
         algorithm: CFTypeRef,
         data_to_sign: CFDataRef,
         error: *mut CFErrorRef,
     ) -> CFDataRef;
     pub(crate) fn SecKeyGeneratePair(
         parameters: CFDictionaryRef,
-        publicKey: *mut SecKeyRef,
-        privateKey: *mut SecKeyRef,
+        publicKey: *mut KeyRef,
+        privateKey: *mut KeyRef,
     ) -> OSStatus;
     pub(crate) fn SecKeyGetTypeID() -> CFTypeID;
-    pub(crate) fn SecKeychainCopyDefault(keychain: *mut SecKeychainRef) -> OSStatus;
+    pub(crate) fn SecKeychainCopyDefault(keychain: *mut KeychainRef) -> OSStatus;
     pub(crate) fn SecKeychainCreate(
         path_name: *const c_char,
         password_length: u32,
         password: *const c_char,
         prompt_user: bool,
         initial_access: CFTypeRef,
-        keychain: *mut SecKeychainRef,
+        keychain: *mut KeychainRef,
     ) -> OSStatus;
-    pub(crate) fn SecKeychainDelete(keychain_or_array: SecKeychainRef) -> OSStatus;
+    pub(crate) fn SecKeychainDelete(keychain_or_array: KeychainRef) -> OSStatus;
     pub(crate) fn SecKeychainGetTypeID() -> CFTypeID;
     pub(crate) fn SecKeychainItemGetTypeID() -> CFTypeID;
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -7,14 +7,10 @@ declare_TCFType!{
     ///
     /// Wrapper for the `SecKeychainItem`/`SecKeychainItemRef` types:
     /// <https://developer.apple.com/documentation/security/seckeychainitemref>
-    SecKeychainItem, SecKeychainItemRef
+    KeychainItem, KeychainItemRef
 }
 
-impl_TCFType!(
-    SecKeychainItem,
-    SecKeychainItemRef,
-    SecKeychainItemGetTypeID
-);
+impl_TCFType!(KeychainItem, KeychainItemRef, SecKeychainItemGetTypeID);
 
 /// Classes of keys supported by Keychain Services (not to be confused with
 /// `SecAttrClass` or `SecType`)
@@ -22,7 +18,7 @@ impl_TCFType!(
 /// Wrapper for the `kSecClass` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecclass>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecClass {
+pub enum Class {
     /// Generic password items.
     ///
     /// Wrapper for the `kSecClassGenericPassword` attribute value. See:
@@ -54,17 +50,17 @@ pub enum SecClass {
     Identity,
 }
 
-impl SecClass {
+impl Class {
     /// Get `CFString` containing the `kSecClass` dictionary value for
     /// this particular `SecClass`.
     pub fn as_CFString(self) -> CFString {
         unsafe {
             CFString::wrap_under_get_rule(match self {
-                SecClass::GenericPassword => kSecClassGenericPassword,
-                SecClass::InternetPassword => kSecClassInternetPassword,
-                SecClass::Certificate => kSecClassCertificate,
-                SecClass::Key => kSecClassKey,
-                SecClass::Identity => kSecClassIdentity,
+                Class::GenericPassword => kSecClassGenericPassword,
+                Class::InternetPassword => kSecClassInternetPassword,
+                Class::Certificate => kSecClassCertificate,
+                Class::Key => kSecClassKey,
+                Class::Identity => kSecClassIdentity,
             })
         }
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -11,41 +11,41 @@ use std::{
     ptr,
 };
 
-use access::SecAccessControl;
-use algorithm::SecKeyAlgorithm;
+use access::AccessControl;
+use algorithm::KeyAlgorithm;
 use attr::*;
-use dictionary::{CFDictionary, CFDictionaryBuilder};
+use dictionary::{Dictionary, DictionaryBuilder};
 use error::Error;
 use ffi::*;
-use item::SecClass;
-use query::{SecItemQueryParams, SecMatchLimit};
-use signature::SecSignature;
+use item::Class;
+use query::{ItemQuery, MatchLimit};
+use signature::Signature;
 
 declare_TCFType!{
     /// Object which represents a cryptographic key.
     ///
     /// Wrapper for the `SecKey`/`SecKeyRef` types:
     /// <https://developer.apple.com/documentation/security/seckeyref>
-    SecKey, SecKeyRef
+    Key, KeyRef
 }
 
-impl_TCFType!(SecKey, SecKeyRef, SecKeyGetTypeID);
+impl_TCFType!(Key, KeyRef, SecKeyGetTypeID);
 
-impl SecKey {
-    /// Find a `SecKey` in the keyring using the given `SecItemQuery`.
+impl Key {
+    /// Find a `Key` in the keyring using the given `ItemQuery`.
     ///
     /// Wrapper for `SecItemCopyMatching`. See:
     /// <https://developer.apple.com/documentation/security/1398306-secitemcopymatching>
-    pub fn find(query: SecItemQueryParams) -> Result<Self, Error> {
-        let mut params = CFDictionaryBuilder::from(query);
-        params.add(unsafe { kSecClass }, &SecClass::Key.as_CFString());
-        params.add(unsafe { kSecMatchLimit }, &SecMatchLimit::One.as_CFType());
+    pub fn find(query: ItemQuery) -> Result<Self, Error> {
+        let mut params = DictionaryBuilder::from(query);
+        params.add(unsafe { kSecClass }, &Class::Key.as_CFString());
+        params.add(unsafe { kSecMatchLimit }, &MatchLimit::One.as_CFType());
         params.add_boolean(unsafe { kSecReturnRef }, true);
 
-        let mut result: SecKeyRef = ptr::null_mut();
+        let mut result: KeyRef = ptr::null_mut();
         let status = unsafe {
             SecItemCopyMatching(
-                CFDictionary::from(params).as_concrete_TypeRef(),
+                Dictionary::from(params).as_concrete_TypeRef(),
                 &mut result as &mut CFTypeRef,
             )
         };
@@ -55,36 +55,31 @@ impl SecKey {
             return Err(e);
         }
 
-        // TODO: is this a create or a get?
-        Ok(unsafe { SecKey::wrap_under_create_rule(result) })
+        Ok(unsafe { Key::wrap_under_create_rule(result) })
     }
 
-    /// Get the `SecAttrApplicationLabel` for this `SecKey`.
-    pub fn application_label(&self) -> Option<SecAttrApplicationLabel> {
-        self.attributes()
-            .find(SecAttr::ApplicationLabel)
-            .map(|tag| {
-                SecAttrApplicationLabel(unsafe {
-                    CFData::wrap_under_get_rule(tag.as_CFTypeRef() as CFDataRef)
-                })
-            })
-    }
-
-    /// Get the `SecAttrApplicationTag` for this `SecKey`.
-    pub fn application_tag(&self) -> Option<SecAttrApplicationTag> {
-        self.attributes().find(SecAttr::ApplicationTag).map(|tag| {
-            SecAttrApplicationTag(unsafe {
+    /// Get the `AttrApplicationLabel` for this `Key`.
+    pub fn application_label(&self) -> Option<AttrApplicationLabel> {
+        self.attributes().find(Attr::ApplicationLabel).map(|tag| {
+            AttrApplicationLabel(unsafe {
                 CFData::wrap_under_get_rule(tag.as_CFTypeRef() as CFDataRef)
             })
         })
     }
 
-    /// Get the `SecAttrLabel` for this `SecKey`.
-    pub fn label(&self) -> Option<SecAttrLabel> {
-        self.attributes().find(SecAttr::Label).map(|label| {
-            SecAttrLabel(unsafe {
-                CFString::wrap_under_get_rule(label.as_CFTypeRef() as CFStringRef)
+    /// Get the `AttrApplicationTag` for this `Key`.
+    pub fn application_tag(&self) -> Option<AttrApplicationTag> {
+        self.attributes().find(Attr::ApplicationTag).map(|tag| {
+            AttrApplicationTag(unsafe {
+                CFData::wrap_under_get_rule(tag.as_CFTypeRef() as CFDataRef)
             })
+        })
+    }
+
+    /// Get the `AttrLabel` for this `Key`.
+    pub fn label(&self) -> Option<AttrLabel> {
+        self.attributes().find(Attr::Label).map(|label| {
+            AttrLabel(unsafe { CFString::wrap_under_get_rule(label.as_CFTypeRef() as CFStringRef) })
         })
     }
 
@@ -92,7 +87,7 @@ impl SecKey {
     ///
     /// Wrapper for the `SecKeyCreateSignature` function. See:
     /// <https://developer.apple.com/documentation/security/1643916-seckeycreatesignature>
-    pub fn sign(&self, alg: SecKeyAlgorithm, data: &[u8]) -> Result<SecSignature, Error> {
+    pub fn sign(&self, alg: KeyAlgorithm, data: &[u8]) -> Result<Signature, Error> {
         let mut error: CFErrorRef = ptr::null_mut();
         let signature = unsafe {
             SecKeyCreateSignature(
@@ -105,7 +100,7 @@ impl SecKey {
 
         if error.is_null() {
             let bytes = unsafe { CFData::wrap_under_create_rule(signature) }.to_vec();
-            Ok(SecSignature::new(alg, bytes))
+            Ok(Signature::new(alg, bytes))
         } else {
             Err(error.into())
         }
@@ -114,8 +109,8 @@ impl SecKey {
     /// Export this key as an external representation.
     ///
     /// If the key is not exportable the operation will fail (e.g. if it
-    /// was generated inside of the Secure Enclave, or if `kSecKeyExtractable`
-    /// is set to NO).
+    /// was generated inside of the Secure Enclave, or if the "Extractable"
+    /// flag is set to NO).
     ///
     /// The data returned depends on the key type:
     ///
@@ -141,18 +136,16 @@ impl SecKey {
         }
     }
 
-    /// Fetch attributes for this `SecKey`.
+    /// Fetch attributes for this `Key`.
     ///
     /// Wrapper for `SecKeyCopyAttributes`. See:
     /// <https://developer.apple.com/documentation/security/1643699-seckeycopyattributes>
-    fn attributes(&self) -> CFDictionary {
-        unsafe {
-            CFDictionary::wrap_under_get_rule(SecKeyCopyAttributes(self.as_concrete_TypeRef()))
-        }
+    fn attributes(&self) -> Dictionary {
+        unsafe { Dictionary::wrap_under_get_rule(SecKeyCopyAttributes(self.as_concrete_TypeRef())) }
     }
 }
 
-impl Debug for SecKey {
+impl Debug for Key {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -166,27 +159,27 @@ impl Debug for SecKey {
 
 /// Public key pairs (i.e. public and private key) stored in the keychain.
 #[derive(Debug)]
-pub struct SecKeyPair {
+pub struct KeyPair {
     /// Public key
-    pub public_key: SecKey,
+    pub public_key: Key,
 
     /// Private key
-    pub private_key: SecKey,
+    pub private_key: Key,
 }
 
-impl SecKeyPair {
-    /// Generate a public/private `SecKey` pair using the given
-    /// `SecKeyGeneratePairParams`.
+impl KeyPair {
+    /// Generate a public/private `KeyPair` using the given
+    /// `GeneratePairParams`.
     ///
     /// Wrapper for the `SecKeyGeneratePair` function. See:
     /// <https://developer.apple.com/documentation/security/1395339-seckeygeneratepair>
-    pub fn generate(params: SecKeyGeneratePairParams) -> Result<SecKeyPair, Error> {
-        let mut public_key_ref: SecKeyRef = ptr::null_mut();
-        let mut private_key_ref: SecKeyRef = ptr::null_mut();
+    pub fn generate(params: GeneratePairParams) -> Result<KeyPair, Error> {
+        let mut public_key_ref: KeyRef = ptr::null_mut();
+        let mut private_key_ref: KeyRef = ptr::null_mut();
 
         let status = unsafe {
             SecKeyGeneratePair(
-                CFDictionary::from(params).as_concrete_TypeRef(),
+                Dictionary::from(params).as_concrete_TypeRef(),
                 &mut public_key_ref,
                 &mut private_key_ref,
             )
@@ -200,13 +193,11 @@ impl SecKeyPair {
         assert!(!public_key_ref.is_null());
         assert!(!private_key_ref.is_null());
 
-        // TODO: check status to ensure success
-        let public_key = unsafe { SecKey::wrap_under_create_rule(public_key_ref) };
-        let private_key = unsafe { SecKey::wrap_under_create_rule(private_key_ref) };
-
-        Ok(SecKeyPair {
-            public_key,
-            private_key,
+        Ok(unsafe {
+            KeyPair {
+                public_key: Key::wrap_under_create_rule(public_key_ref),
+                private_key: Key::wrap_under_create_rule(private_key_ref),
+            }
         })
     }
 }
@@ -217,15 +208,15 @@ impl SecKeyPair {
 /// For more information on generating cryptographic keys in a keychain, see:
 /// <https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/generating_new_cryptographic_keys>
 #[derive(Clone, Debug)]
-pub struct SecKeyGeneratePairParams {
-    key_type: SecAttrKeyType,
+pub struct GeneratePairParams {
+    key_type: AttrKeyType,
     key_size: usize,
-    attrs: CFDictionaryBuilder,
+    attrs: DictionaryBuilder,
 }
 
-impl SecKeyGeneratePairParams {
-    /// Create a new `SecKeyGeneratePairParams`
-    pub fn new(key_type: SecAttrKeyType, key_size: usize) -> Self {
+impl GeneratePairParams {
+    /// Create a new `GeneratePairParams`
+    pub fn new(key_type: AttrKeyType, key_size: usize) -> Self {
         Self {
             key_type,
             key_size,
@@ -233,13 +224,13 @@ impl SecKeyGeneratePairParams {
         }
     }
 
-    /// Set the access control policy (a.k.a. ACL) for the `SecKey`.
+    /// Set the access control policy (a.k.a. ACL) for the `Key`.
     ///
     /// Wrapper for the `kSecAttrAccessControl` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattraccesscontrol>
-    pub fn access_control(mut self, access_control: &SecAccessControl) -> Self {
+    pub fn access_control(mut self, access_control: &AccessControl) -> Self {
         self.attrs
-            .add(SecAttr::AccessControl, &access_control.as_CFType());
+            .add(Attr::AccessControl, &access_control.as_CFType());
         self
     }
 
@@ -250,7 +241,7 @@ impl SecKeyGeneratePairParams {
     /// <https://developer.apple.com/documentation/security/ksecattrapplicationtag>
     pub fn application_tag<T>(mut self, tag: T) -> Self
     where
-        T: Into<SecAttrApplicationTag>,
+        T: Into<AttrApplicationTag>,
     {
         self.attrs.add_attr(&tag.into());
         self
@@ -261,7 +252,7 @@ impl SecKeyGeneratePairParams {
     /// Wrapper for the `kSecAttrIsPermanent` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrispermanent>
     pub fn permanent(mut self, value: bool) -> Self {
-        self.attrs.add_boolean(SecAttr::IsPermanent, value);
+        self.attrs.add_boolean(Attr::IsPermanent, value);
         self
     }
 
@@ -270,7 +261,7 @@ impl SecKeyGeneratePairParams {
     ///
     /// Wrapper for the `kSecAttrLabel` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrlabel>
-    pub fn label<L: Into<SecAttrLabel>>(mut self, label: L) -> Self {
+    pub fn label<L: Into<AttrLabel>>(mut self, label: L) -> Self {
         self.attrs.add_attr(&label.into());
         self
     }
@@ -281,7 +272,7 @@ impl SecKeyGeneratePairParams {
     /// Wrapper for the `kSecAttrSynchronizable` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrsynchronizable>
     pub fn synchronizable(mut self, value: bool) -> Self {
-        self.attrs.add_boolean(SecAttr::Synchronizable, value);
+        self.attrs.add_boolean(Attr::Synchronizable, value);
         self
     }
 
@@ -289,20 +280,20 @@ impl SecKeyGeneratePairParams {
     ///
     /// Wrapper for the `kSecAttrTokenID` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrtokenid>
-    pub fn token_id(mut self, value: SecAttrTokenId) -> Self {
+    pub fn token_id(mut self, value: AttrTokenId) -> Self {
         self.attrs.add_attr(&value);
         self
     }
 }
 
-impl From<SecKeyGeneratePairParams> for CFDictionary {
-    fn from(params: SecKeyGeneratePairParams) -> CFDictionary {
-        let mut result = CFDictionaryBuilder::new();
+impl From<GeneratePairParams> for Dictionary {
+    fn from(params: GeneratePairParams) -> Dictionary {
+        let mut result = DictionaryBuilder::new();
         result.add_attr(&params.key_type);
-        result.add_number(SecAttr::KeySizeInBits, params.key_size as i64);
+        result.add_number(Attr::KeySizeInBits, params.key_size as i64);
         result.add(
             unsafe { kSecPrivateKeyAttrs },
-            &CFDictionary::from(params.attrs),
+            &Dictionary::from(params.attrs),
         );
         result.into()
     }

--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -11,27 +11,27 @@ declare_TCFType!{
     ///
     /// Wrapper for the `SecKeychain`/`SecKeychainRef` types:
     /// <https://developer.apple.com/documentation/security/seckeychainref>
-    SecKeychain, SecKeychainRef
+    Keychain, KeychainRef
 }
 
-impl_TCFType!(SecKeychain, SecKeychainRef, SecKeychainGetTypeID);
+impl_TCFType!(Keychain, KeychainRef, SecKeychainGetTypeID);
 
-impl SecKeychain {
+impl Keychain {
     /// Find the default keychain. Returns an `Error` result with a kind of
     /// `ErrorKind::NoDefaultKeychain` if there is no default keychain.
     ///
-    /// This is a non-panicking alternative to `SecKeychain::default()`.
+    /// This is a non-panicking alternative to `Keychain::default()`.
     ///
     /// Wrapper for the `SecKeychainCopyDefault` function. See:
     /// <https://developer.apple.com/documentation/security/1400743-seckeychaincopydefault>
-    pub fn find_default() -> Result<SecKeychain, Error> {
-        let mut result: SecKeychainRef = ptr::null_mut();
+    pub fn find_default() -> Result<Keychain, Error> {
+        let mut result: KeychainRef = ptr::null_mut();
         let status = unsafe { SecKeychainCopyDefault(&mut result) };
 
         if let Some(e) = Error::maybe_from_OSStatus(status) {
             Err(e)
         } else {
-            Ok(unsafe { SecKeychain::wrap_under_create_rule(result) })
+            Ok(unsafe { Keychain::wrap_under_create_rule(result) })
         }
     }
 
@@ -41,9 +41,9 @@ impl SecKeychain {
     ///
     /// Wrapper for the `SecKeychainCreate` function. See:
     /// <https://developer.apple.com/documentation/security/1401214-seckeychaincreate>
-    pub fn create(path: &Path, password: Option<&str>) -> Result<SecKeychain, Error> {
+    pub fn create(path: &Path, password: Option<&str>) -> Result<Keychain, Error> {
         let path_cstring = CString::new(path.as_os_str().as_bytes()).unwrap();
-        let mut result: SecKeychainRef = ptr::null_mut();
+        let mut result: KeychainRef = ptr::null_mut();
 
         let status = match password {
             Some(pw) => unsafe {
@@ -71,7 +71,7 @@ impl SecKeychain {
         if let Some(e) = Error::maybe_from_OSStatus(status) {
             Err(e)
         } else {
-            Ok(unsafe { SecKeychain::wrap_under_create_rule(result) })
+            Ok(unsafe { Keychain::wrap_under_create_rule(result) })
         }
     }
 
@@ -90,8 +90,8 @@ impl SecKeychain {
     }
 }
 
-impl Default for SecKeychain {
-    fn default() -> SecKeychain {
-        Self::find_default().expect("no default SecKeychain available")
+impl Default for Keychain {
+    fn default() -> Keychain {
+        Self::find_default().expect("no default keychain available")
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -7,7 +7,7 @@ use core_foundation::{
 };
 
 use attr::*;
-use dictionary::CFDictionaryBuilder;
+use dictionary::DictionaryBuilder;
 use ffi::*;
 
 /// Limit the number of matched items to one or an unlimited number.
@@ -15,7 +15,7 @@ use ffi::*;
 /// Wrapper for the `kSecMatchLimit` attribute key. See:
 /// <https://developer.apple.com/documentation/security/ksecmatchlimit>
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum SecMatchLimit {
+pub enum MatchLimit {
     /// Match exactly one item.
     ///
     /// Wrapper for the `kSecMatchLimitOne` attribute value. See:
@@ -36,16 +36,16 @@ pub enum SecMatchLimit {
     All,
 }
 
-impl SecMatchLimit {
+impl MatchLimit {
     /// Get `CFType` containing the `kSecMatchLimit` dictionary value for
     /// this particular `SecMatchLimit`.
     pub fn as_CFType(self) -> CFType {
         match self {
-            SecMatchLimit::One => {
+            MatchLimit::One => {
                 unsafe { CFString::wrap_under_get_rule(kSecMatchLimitOne) }.as_CFType()
             }
-            SecMatchLimit::Number(n) => CFNumber::from(n as i64).as_CFType(),
-            SecMatchLimit::All => {
+            MatchLimit::Number(n) => CFNumber::from(n as i64).as_CFType(),
+            MatchLimit::All => {
                 unsafe { CFString::wrap_under_get_rule(kSecMatchLimitAll) }.as_CFType()
             }
         }
@@ -57,9 +57,9 @@ impl SecMatchLimit {
 /// For more information, see "Search Attribute Keys and Values":
 /// <https://developer.apple.com/documentation/security/keychain_services/keychain_items/search_attribute_keys_and_values>
 #[derive(Default, Debug)]
-pub struct SecItemQueryParams(CFDictionaryBuilder);
+pub struct ItemQuery(DictionaryBuilder);
 
-impl SecItemQueryParams {
+impl ItemQuery {
     /// Create a new keychain item query builder
     pub fn new() -> Self {
         Self::default()
@@ -74,7 +74,7 @@ impl SecItemQueryParams {
     ///
     /// Wrapper for the `kSecAttrApplicationLabel` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrlabel>
-    pub fn application_label<L: Into<SecAttrApplicationLabel>>(mut self, label: L) -> Self {
+    pub fn application_label<L: Into<AttrApplicationLabel>>(mut self, label: L) -> Self {
         self.0.add_attr(&label.into());
         self
     }
@@ -85,7 +85,7 @@ impl SecItemQueryParams {
     /// <https://developer.apple.com/documentation/security/ksecattrapplicationtag>
     pub fn application_tag<T>(mut self, tag: T) -> Self
     where
-        T: Into<SecAttrApplicationTag>,
+        T: Into<AttrApplicationTag>,
     {
         self.0.add_attr(&tag.into());
         self
@@ -95,7 +95,7 @@ impl SecItemQueryParams {
     ///
     /// Wrapper for the `kSecAttrKeyClass` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrkeyclass>
-    pub fn key_class(mut self, key_class: SecAttrKeyClass) -> Self {
+    pub fn key_class(mut self, key_class: AttrKeyClass) -> Self {
         self.0.add_attr(&key_class);
         self
     }
@@ -104,7 +104,7 @@ impl SecItemQueryParams {
     ///
     /// Wrapper for the `kSecAttrKeyType` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrkeytype>
-    pub fn key_type(mut self, key_type: SecAttrKeyType) -> Self {
+    pub fn key_type(mut self, key_type: AttrKeyType) -> Self {
         self.0.add_attr(&key_type);
         self
     }
@@ -113,7 +113,7 @@ impl SecItemQueryParams {
     ///
     /// Wrapper for the `kSecAttrLabel` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrlabel>
-    pub fn label<L: Into<SecAttrLabel>>(mut self, label: L) -> Self {
+    pub fn label<L: Into<AttrLabel>>(mut self, label: L) -> Self {
         self.0.add_attr(&label.into());
         self
     }
@@ -123,7 +123,7 @@ impl SecItemQueryParams {
     /// Wrapper for the `kSecAttrIsPermanent` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrispermanent>
     pub fn permanent(mut self, value: bool) -> Self {
-        self.0.add_boolean(SecAttr::IsPermanent, value);
+        self.0.add_boolean(Attr::IsPermanent, value);
         self
     }
 
@@ -132,7 +132,7 @@ impl SecItemQueryParams {
     /// Wrapper for the `kSecAttrSynchronizable` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrsynchronizable>
     pub fn synchronizable(mut self, value: bool) -> Self {
-        self.0.add_boolean(SecAttr::Synchronizable, value);
+        self.0.add_boolean(Attr::Synchronizable, value);
         self
     }
 
@@ -141,7 +141,7 @@ impl SecItemQueryParams {
     ///
     /// Wrapper for the `kSecAttrTokenID` attribute key. See:
     /// <https://developer.apple.com/documentation/security/ksecattrtokenid>
-    pub fn token_id(mut self, value: SecAttrTokenId) -> Self {
+    pub fn token_id(mut self, value: AttrTokenId) -> Self {
         self.0.add_attr(&value);
         self
     }
@@ -157,8 +157,8 @@ impl SecItemQueryParams {
     }
 }
 
-impl From<SecItemQueryParams> for CFDictionaryBuilder {
-    fn from(params: SecItemQueryParams) -> CFDictionaryBuilder {
+impl From<ItemQuery> for DictionaryBuilder {
+    fn from(params: ItemQuery) -> DictionaryBuilder {
         params.0
     }
 }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -3,24 +3,24 @@
 //! This type doesn't map directly to any type in the Keychain Services API,
 //! but instead provides a newtype for signatures this binding produces.
 
-use algorithm::SecKeyAlgorithm;
+use algorithm::KeyAlgorithm;
 
 /// Cryptographic signatures
 #[derive(Clone, Debug)]
-pub struct SecSignature {
-    alg: SecKeyAlgorithm,
+pub struct Signature {
+    alg: KeyAlgorithm,
     bytes: Vec<u8>,
 }
 
-impl SecSignature {
+impl Signature {
     /// Create a new `Signature`
-    pub(crate) fn new(alg: SecKeyAlgorithm, bytes: Vec<u8>) -> Self {
+    pub(crate) fn new(alg: KeyAlgorithm, bytes: Vec<u8>) -> Self {
         // TODO: restrict valid algorithms to signature algorithms?
         Self { alg, bytes }
     }
 
     /// Get the algorithm which produced this signature
-    pub fn algorithm(&self) -> SecKeyAlgorithm {
+    pub fn algorithm(&self) -> KeyAlgorithm {
         self.alg
     }
 
@@ -35,14 +35,14 @@ impl SecSignature {
     }
 }
 
-impl AsRef<[u8]> for SecSignature {
+impl AsRef<[u8]> for Signature {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl From<SecSignature> for Vec<u8> {
-    fn from(sig: SecSignature) -> Vec<u8> {
+impl From<Signature> for Vec<u8> {
+    fn from(sig: Signature) -> Vec<u8> {
         sig.into_vec()
     }
 }

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -15,22 +15,19 @@ const TEST_MESSAGE: &[u8] = b"Embed confidential information in items that you s
 #[test]
 fn generate_and_sign_with_ecdsa_keys() {
     let acl =
-        SecAccessControl::create_with_flags(SecAttrAccessible::WhenUnlocked, Default::default())
-            .unwrap();
+        AccessControl::create_with_flags(AttrAccessible::WhenUnlocked, Default::default()).unwrap();
 
     let generate_params =
-        SecKeyGeneratePairParams::new(SecAttrKeyType::EcSecPrimeRandom, 256).access_control(&acl);
+        GeneratePairParams::new(AttrKeyType::EcSecPrimeRandom, 256).access_control(&acl);
 
-    let keypair = SecKeyPair::generate(generate_params).unwrap();
+    let keypair = KeyPair::generate(generate_params).unwrap();
 
     let public_key_bytes = keypair.public_key.to_external_representation().unwrap();
 
     let signature = keypair
         .private_key
-        .sign(
-            SecKeyAlgorithm::ECDSASignatureMessageX962SHA256,
-            TEST_MESSAGE,
-        ).unwrap();
+        .sign(KeyAlgorithm::ECDSASignatureMessageX962SHA256, TEST_MESSAGE)
+        .unwrap();
 
     ring::signature::verify(
         &ring::signature::ECDSA_P256_SHA256_ASN1,

--- a/tests/interactive.rs
+++ b/tests/interactive.rs
@@ -14,18 +14,17 @@ extern crate keychain_services;
 use keychain_services::*;
 
 /// Generate a `SecKeyPair` for testing purposes
-fn generate_keypair(tag: &str, label: &str) -> SecKeyPair {
-    let acl =
-        SecAccessControl::create_with_flags(SecAttrAccessible::WhenUnlocked, Default::default())
-            .unwrap();
+fn generate_keypair(tag: &str, label: &str) -> KeyPair {
+    let acl = SecAccessControl::create_with_flags(AttrAccessible::WhenUnlocked, Default::default())
+        .unwrap();
 
-    let generate_params = SecKeyGeneratePairParams::new(SecAttrKeyType::EcSecPrimeRandom, 256)
+    let generate_params = GeneratePairParams::new(AttrKeyType::EcSecPrimeRandom, 256)
         .access_control(acl)
         .application_tag(tag)
         .label(label)
         .permanent(true);
 
-    SecKeyPair::generate(generate_params).unwrap()
+    KeyPair::generate(generate_params).unwrap()
 }
 
 /// `SecKey` query
@@ -36,9 +35,9 @@ fn seckey_query() {
         "keychain-services.rs integration test query key",
     );
 
-    let private_key_query = SecItemQueryParams::new()
-        .key_class(SecAttrKeyClass::Private)
-        .key_type(SecAttrKeyType::EcSecPrimeRandom)
+    let private_key_query = ItemQuery::new()
+        .key_class(AttrKeyClass::Private)
+        .key_type(AttrKeyType::EcSecPrimeRandom)
         .application_label(keypair.public_key.application_label().unwrap());
 
     let private_key = SecKey::find(private_key_query).unwrap();


### PR DESCRIPTION
Security Framework adds a leading `Sec` prefix to all type and function names to namespace them.

This makes sense given it's a C library, but is a bit redundant in a Rust binding.

The underlying types and functions wrapped are meticulously documented, so we don't really gain much by mimicking this naming scheme in a binding.