### PR TITLE
v0.1.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,18 +1,14 @@
+## [0.1.1] (2018-12-10)
+
+- Update to Rust 2018 edition ([#20])
+- Update links to use keychain-services.rs repo name ([#19])
+
 ## [0.1.0] (2018-11-06)
 
-[0.1.0]: https://github.com/iqlusioninc/keychain-services.rs/pull/18
-
-- [#17](https://github.com/iqlusioninc/keychain-services.rs/pull/17)
-  Initial password support.
-
-- [#16](https://github.com/iqlusioninc/keychain-services.rs/pull/16)
-  Factor related types into modules.
-
-- [#15](https://github.com/iqlusioninc/keychain-services.rs/pull/15)
-  Remove 'Sec*' prefix from all type names.
-
-- [#14](https://github.com/iqlusioninc/keychain-services.rs/pull/14)
-  Implement keychain types and refactor builders.
+- Initial password support ([#17])
+- Factor related types into modules ([#16])
+- Remove `Sec*` prefix from all type names ([#15])
+- Implement keychain types and refactor builders ([#14])
 
 ## 0.0.2 (2018-11-01)
 
@@ -21,3 +17,12 @@
 ## 0.0.1 (2018-10-31)
 
 - Initial release
+
+[0.1.1]: https://github.com/iqlusioninc/keychain-services.rs/pull/21
+[#20]: https://github.com/iqlusioninc/keychain-services.rs/pull/20
+[#19]: https://github.com/iqlusioninc/keychain-services.rs/pull/19
+[0.1.0]: https://github.com/iqlusioninc/keychain-services.rs/pull/18
+[#17]: https://github.com/iqlusioninc/keychain-services.rs/pull/17
+[#16]: https://github.com/iqlusioninc/keychain-services.rs/pull/16
+[#15]: https://github.com/iqlusioninc/keychain-services.rs/pull/15
+[#14]: https://github.com/iqlusioninc/keychain-services.rs/pull/14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description   = """
                 access to cryptographic keys stored in the Secure Enclave
                 Processor (SEP).
                 """
-version       = "0.1.0"
+version       = "0.1.1"
 authors       = ["Tony Arcieri <tony@iqlusion.io>"]
 license       = "Apache-2.0"
 homepage      = "https://keychain-services.rs/"


### PR DESCRIPTION
- Update to Rust 2018 edition (#20)
- Update links to use keychain-services.rs repo name (#19)